### PR TITLE
Deploy as bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,36 @@ An [Apache Brooklyn](https://brooklyn.apache.org/) entity that invokes
 
 Throughput can be reconfigured post-deployment.
 
-Releasing
----
+## Building
+
+From the top level of the project:
+ 
+    mvn clean install
+
+
+## Installing
+
+Add the bundle to a running Brooklyn or AMP server:
+
+    br catalog add target/brooklyn-jmeter-1.0.0-SNAPSHOT.jar 
+
+
+## Example Usage
+
+Deploy the jmeter entity, configuring it with the target IP (or hostname) and the port. For example:
+
+    name: jmeter
+    location: aws-ec2:us-east-1
+    services:
+      - type: jmeter
+        brooklyn.config:
+          target: 34.240.101.234
+          port: '8000'
+
+## Releasing
 
 ```
-mvn -Psonatype-oss-release release:clean release:prepare release:perform 
+mvn -Psonatype-oss-release release:clean release:prepare release:perform
 ```
 
-Example
--------
 
-The [catalog.bom](catalog.bom) contains a simple example application that generates http requests on a specified `target`, `port` and `path` 

--- a/catalog/jmeter/catalog.bom
+++ b/catalog/jmeter/catalog.bom
@@ -1,46 +1,35 @@
 brooklyn.catalog:
-  version: "0.11.0-SNAPSHOT"
+  version: "1.0.0-SNAPSHOT" # JMETER_ENTITY_VERSION
   publish:
     license_code: Apache-2.0
     overview: README.md
 
-  brooklyn.libraries:
-  - # add the latest snapshot from https://oss.sonatype.org/content/repositories/snapshots/io/cloudsoft/jmeter/brooklyn-jmeter/0.11.0-SNAPSHOT/
-
-
   items:
-    - id: jmeter-load-app
-      iconUrl: https://raw.githubusercontent.com/cloudsoft/jmeter-entity/501a3415af373f9071117d8e530e57f728d92154/src/main/resources/io/cloudsoft/jmeter/logo.jpg
+    - id: jmeter
+      iconUrl: classpath://io/cloudsoft/jmeter/logo.jpg
       name: Load Generator
       description: Runs Apache JMeter against the configured endpoint.
-      itemType: template
-      item:
-        services:
-          - type: org.apache.brooklyn.entity.stock.BasicApplication
-            brooklyn.parameters:
-              - name: target
-                type: string
-                label: Domain name or IP address of the target
-                description: Domain name or IP address of the target
-                pinned: true
-                constraints:
-                - required
-              - name: port
-                type: int
-                label: The target port
-                description: The target port
-                pinned: true
-                constraints:
-                - required
-              - name: path
-                type: string
-                label: The target path (optional)
-                description: The target path (optional)
-                pinned: true
-
-            brooklyn.children:
-              - type: jmeter
-
-    - id: jmeter
+      itemType: entity
       item:
         type: io.cloudsoft.jmeter.JMeterNode
+        brooklyn.parameters:
+          - name: target
+            type: string
+            label: Domain name or IP address of the target
+            description: Domain name or IP address of the target
+            pinned: true
+            constraints:
+            - required
+          - name: port
+            type: int
+            label: The target port
+            description: The target port
+            pinned: true
+            constraints:
+            - required
+          - name: path
+            type: string
+            label: The target path
+            description: The target path
+            default: '/'
+

--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" name="${project.artifactId}-${project.version}">
-    <feature name="${project.artifactId}" version="${project.version}">
-        <bundle>mvn:${project.groupId}/${project.artifactId}/${project.version}</bundle>
-    </feature>
-</features>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.cloudsoft.jmeter</groupId>
     <artifactId>brooklyn-jmeter</artifactId>
-    <version>0.12.0-SNAPSHOT</version><!-- BROOKLYN_VERSION -->
+    <version>1.0.0-SNAPSHOT</version><!-- JMETER_ENTITY_VERSION -->
     <packaging>bundle</packaging>
 
     <name>brooklyn-jmeter</name>
@@ -36,7 +36,9 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <brooklyn.version>0.12.0-SNAPSHOT</brooklyn.version><!-- BROOKLYN_VERSION -->
+        <brooklyn.version>1.0.0-SNAPSHOT</brooklyn.version><!-- BROOKLYN_VERSION -->
+        <jsr305.version>2.0.1</jsr305.version>
+        <slf4j.version>1.6.6</slf4j.version>
     </properties>
 
     <repositories>
@@ -87,12 +89,12 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>2.0.1</version>
+            <version>${jsr305.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.6</version>
+            <version>${slf4j.version}</version>
         </dependency>
     </dependencies>
 
@@ -102,14 +104,10 @@
                 <directory>src/main/resources</directory>
             </resource>
             <resource>
-                <directory>catalog</directory>
+                <directory>catalog/jmeter</directory>
                 <filtering>false</filtering>
-			</resource>
-            <resource>
-                <directory>feature</directory>
-                <filtering>true</filtering>
-			</resource>
-		</resources>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -134,33 +132,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-artifact</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>${project.build.outputDirectory}/jmeter/catalog.bom</file>
-                                    <classifier>jmeter</classifier>
-                                    <type>bom</type>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.outputDirectory}/feature.xml</file>
-                                    <classifier>features</classifier>
-                                    <type>xml</type>
-                                </artifact>
-                            </artifacts>
-                        </configuration>
-                    </execution>
-                </executions>
-			</plugin>
         </plugins>
     </build>
     

--- a/src/main/java/io/cloudsoft/jmeter/JMeterNode.java
+++ b/src/main/java/io/cloudsoft/jmeter/JMeterNode.java
@@ -11,6 +11,7 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
+import org.apache.brooklyn.entity.java.UsesJava;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
@@ -18,14 +19,16 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
         description = "Uses Apache JMeter to generate load against a configurable URL",
         iconUrl = "classpath://io/cloudsoft/jmeter/logo.jpg")
 @ImplementedBy(JMeterNodeImpl.class)
-public interface JMeterNode extends SoftwareProcess {
+public interface JMeterNode extends SoftwareProcess, UsesJava {
 
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION,
-            "3.1");
+            "3.3");
 
     AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = ConfigKeys.newSensorAndConfigKeyWithDefault(
             Attributes.DOWNLOAD_URL,
             "http://download.nextag.com/apache/jmeter/binaries/apache-jmeter-${version}.tgz");
+
+    ConfigKey<String> JAVA_VERSION_REQUIRED = ConfigKeys.newConfigKeyWithDefault(UsesJava.JAVA_VERSION_REQUIRED, "1.8");
 
     @SetFromFlag("plan")
     AttributeSensorAndConfigKey<String, String> TEST_PLAN_URL = ConfigKeys.newStringSensorAndConfigKey(


### PR DESCRIPTION
Deploy to Brooklyn catalog as a single bundle.

- Bumps brooklyn dependency to 1.0.0-snapshot
- Deletes feature.xml (not needed as it’s just a single bundle)
- Puts catalog.bom at root of bundle
- Removes ‘template’ item; add only single ‘entity’ item.
